### PR TITLE
add Telegram bot download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ Bypasses YouTube's "Sign in to confirm you're not a bot" restrictions by integra
 ### Jellyfin Integration
 Automatically generates `.nfo` metadata files for downloaded videos, enabling Jellyfin to properly index and display Video title and description and other basic metadata.
 
+### Telegram Bot
+Optional Telegram bot support to queue downloads by sending links directly in chat.
+
+Features:
+- `/config` menu to set default download format/quality per chat
+- One or multiple links per message
+- Basic URL sanitization (only valid public `http/https` URLs)
+- Completion feedback (`✅` on success, `❌` with error on failure)
+- Stall and long-running download notifications
+
+Environment variables:
+
+```env
+TELEGRAM_BOT_ENABLED=true
+TELEGRAM_BOT_TOKEN=<your_bot_token>
+TELEGRAM_ALLOWED_CHAT_IDS=123456789,-100987654321
+TELEGRAM_STALL_TIMEOUT_SECONDS=180
+TELEGRAM_HARD_TIMEOUT_SECONDS=7200
+TELEGRAM_MAX_URLS_PER_MESSAGE=10
+```
+
+Notes:
+- `TELEGRAM_ALLOWED_CHAT_IDS` is required when bot is enabled.
+- Chat IDs can be private chats or groups/supergroups.
+- Bot configuration is persisted in `STATE_DIR/telegram_bot_config.json`.
+
 ## Run using Docker Compose
 
 ```yaml
@@ -22,4 +48,3 @@ services:
     container_name: metube
     [...]
 ```
-

--- a/app/main.py
+++ b/app/main.py
@@ -17,102 +17,123 @@ import re
 from watchfiles import DefaultFilter, Change, awatch
 
 from ytdl import DownloadQueueNotifier, DownloadQueue
+from telegram_bot import TelegramBot
 from yt_dlp.version import __version__ as yt_dlp_version
 
-log = logging.getLogger('main')
+log = logging.getLogger("main")
+
 
 def parseLogLevel(logLevel):
     match logLevel:
-        case 'DEBUG':
+        case "DEBUG":
             return logging.DEBUG
-        case 'INFO':
+        case "INFO":
             return logging.INFO
-        case 'WARNING':
+        case "WARNING":
             return logging.WARNING
-        case 'ERROR':
+        case "ERROR":
             return logging.ERROR
-        case 'CRITICAL':
+        case "CRITICAL":
             return logging.CRITICAL
         case _:
             return None
 
+
 # Configure logging before Config() uses it so early messages are not dropped.
 # Only configure if no handlers are set (avoid clobbering hosting app settings).
 if not logging.getLogger().hasHandlers():
-    logging.basicConfig(level=parseLogLevel(os.environ.get('LOGLEVEL', 'INFO')) or logging.INFO)
+    logging.basicConfig(
+        level=parseLogLevel(os.environ.get("LOGLEVEL", "INFO")) or logging.INFO
+    )
+
 
 class Config:
     _DEFAULTS = {
-        'DOWNLOAD_DIR': '.',
-        'AUDIO_DOWNLOAD_DIR': '%%DOWNLOAD_DIR',
-        'TEMP_DIR': '%%DOWNLOAD_DIR',
-        'DOWNLOAD_DIRS_INDEXABLE': 'false',
-        'CUSTOM_DIRS': 'true',
-        'CREATE_CUSTOM_DIRS': 'true',
-        'CUSTOM_DIRS_EXCLUDE_REGEX': r'(^|/)[.@].*$',
-        'DELETE_FILE_ON_TRASHCAN': 'false',
-        'STATE_DIR': '.',
-        'URL_PREFIX': '',
-        'PUBLIC_HOST_URL': 'download/',
-        'PUBLIC_HOST_AUDIO_URL': 'audio_download/',
-        'OUTPUT_TEMPLATE': '%(title)s.%(ext)s',
-        'OUTPUT_TEMPLATE_CHAPTER': '%(title)s - %(section_number)02d - %(section_title)s.%(ext)s',
-        'OUTPUT_TEMPLATE_PLAYLIST': '%(playlist_title)s/%(title)s.%(ext)s',
-        'DEFAULT_OPTION_PLAYLIST_ITEM_LIMIT' : '0',
-        'YTDL_OPTIONS': '{}',
-        'YTDL_OPTIONS_FILE': '',
-        'ROBOTS_TXT': '',
-        'HOST': '0.0.0.0',
-        'PORT': '8081',
-        'HTTPS': 'false',
-        'CERTFILE': '',
-        'KEYFILE': '',
-        'BASE_DIR': '',
-        'DEFAULT_THEME': 'auto',
-        'MAX_CONCURRENT_DOWNLOADS': 3,
-        'LOGLEVEL': 'INFO',
-        'ENABLE_ACCESSLOG': 'false',
-        'SC_THREAD_COUNT': '16',
-        'SC_USE_FFMPEG': 'false',
+        "DOWNLOAD_DIR": ".",
+        "AUDIO_DOWNLOAD_DIR": "%%DOWNLOAD_DIR",
+        "TEMP_DIR": "%%DOWNLOAD_DIR",
+        "DOWNLOAD_DIRS_INDEXABLE": "false",
+        "CUSTOM_DIRS": "true",
+        "CREATE_CUSTOM_DIRS": "true",
+        "CUSTOM_DIRS_EXCLUDE_REGEX": r"(^|/)[.@].*$",
+        "DELETE_FILE_ON_TRASHCAN": "false",
+        "STATE_DIR": ".",
+        "URL_PREFIX": "",
+        "PUBLIC_HOST_URL": "download/",
+        "PUBLIC_HOST_AUDIO_URL": "audio_download/",
+        "OUTPUT_TEMPLATE": "%(title)s.%(ext)s",
+        "OUTPUT_TEMPLATE_CHAPTER": "%(title)s - %(section_number)02d - %(section_title)s.%(ext)s",
+        "OUTPUT_TEMPLATE_PLAYLIST": "%(playlist_title)s/%(title)s.%(ext)s",
+        "DEFAULT_OPTION_PLAYLIST_ITEM_LIMIT": "0",
+        "YTDL_OPTIONS": "{}",
+        "YTDL_OPTIONS_FILE": "",
+        "ROBOTS_TXT": "",
+        "HOST": "0.0.0.0",
+        "PORT": "8081",
+        "HTTPS": "false",
+        "CERTFILE": "",
+        "KEYFILE": "",
+        "BASE_DIR": "",
+        "DEFAULT_THEME": "auto",
+        "MAX_CONCURRENT_DOWNLOADS": 3,
+        "LOGLEVEL": "INFO",
+        "ENABLE_ACCESSLOG": "false",
+        "SC_THREAD_COUNT": "16",
+        "SC_USE_FFMPEG": "false",
+        "TELEGRAM_BOT_ENABLED": "false",
+        "TELEGRAM_STALL_TIMEOUT_SECONDS": "180",
+        "TELEGRAM_HARD_TIMEOUT_SECONDS": "7200",
+        "TELEGRAM_MAX_URLS_PER_MESSAGE": "10",
     }
 
-    _BOOLEAN = ('DOWNLOAD_DIRS_INDEXABLE', 'CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN', 'HTTPS', 'ENABLE_ACCESSLOG', 'SC_USE_FFMPEG')
+    _BOOLEAN = (
+        "DOWNLOAD_DIRS_INDEXABLE",
+        "CUSTOM_DIRS",
+        "CREATE_CUSTOM_DIRS",
+        "DELETE_FILE_ON_TRASHCAN",
+        "HTTPS",
+        "ENABLE_ACCESSLOG",
+        "SC_USE_FFMPEG",
+        "TELEGRAM_BOT_ENABLED",
+    )
 
     def __init__(self):
         for k, v in self._DEFAULTS.items():
             setattr(self, k, os.environ.get(k, v))
 
         for k, v in self.__dict__.items():
-            if isinstance(v, str) and v.startswith('%%'):
+            if isinstance(v, str) and v.startswith("%%"):
                 setattr(self, k, getattr(self, v[2:]))
             if k in self._BOOLEAN:
-                if v not in ('true', 'false', 'True', 'False', 'on', 'off', '1', '0'):
-                    log.error(f'Environment variable "{k}" is set to a non-boolean value "{v}"')
+                if v not in ("true", "false", "True", "False", "on", "off", "1", "0"):
+                    log.error(
+                        f'Environment variable "{k}" is set to a non-boolean value "{v}"'
+                    )
                     sys.exit(1)
-                setattr(self, k, v in ('true', 'True', 'on', '1'))
+                setattr(self, k, v in ("true", "True", "on", "1"))
 
-        if not self.URL_PREFIX.endswith('/'):
-            self.URL_PREFIX += '/'
+        if not self.URL_PREFIX.endswith("/"):
+            self.URL_PREFIX += "/"
 
         # Convert relative addresses to absolute addresses to prevent the failure of file address comparison
-        if self.YTDL_OPTIONS_FILE and self.YTDL_OPTIONS_FILE.startswith('.'):
+        if self.YTDL_OPTIONS_FILE and self.YTDL_OPTIONS_FILE.startswith("."):
             self.YTDL_OPTIONS_FILE = str(Path(self.YTDL_OPTIONS_FILE).resolve())
 
-        success,_ = self.load_ytdl_options()
+        success, _ = self.load_ytdl_options()
         if not success:
             sys.exit(1)
 
     def load_ytdl_options(self) -> tuple[bool, str]:
         try:
-            self.YTDL_OPTIONS = json.loads(os.environ.get('YTDL_OPTIONS', '{}'))
+            self.YTDL_OPTIONS = json.loads(os.environ.get("YTDL_OPTIONS", "{}"))
             assert isinstance(self.YTDL_OPTIONS, dict)
         except (json.decoder.JSONDecodeError, AssertionError):
-            msg = 'Environment variable YTDL_OPTIONS is invalid'
+            msg = "Environment variable YTDL_OPTIONS is invalid"
             log.error(msg)
             return (False, msg)
 
         if not self.YTDL_OPTIONS_FILE:
-            return (True, '')
+            return (True, "")
 
         log.info(f'Loading yt-dlp custom options from "{self.YTDL_OPTIONS_FILE}"')
         if not os.path.exists(self.YTDL_OPTIONS_FILE):
@@ -124,12 +145,13 @@ class Config:
                 opts = json.load(json_data)
             assert isinstance(opts, dict)
         except (json.decoder.JSONDecodeError, AssertionError):
-            msg = 'YTDL_OPTIONS_FILE contents is invalid'
+            msg = "YTDL_OPTIONS_FILE contents is invalid"
             log.error(msg)
             return (False, msg)
 
         self.YTDL_OPTIONS.update(opts)
-        return (True, '')
+        return (True, "")
+
 
 config = Config()
 # Align root logger level with Config (keeps a single source of truth).
@@ -139,14 +161,15 @@ logging.getLogger().setLevel(parseLogLevel(str(config.LOGLEVEL)) or logging.INFO
 logging.getLogger("watchfiles").setLevel(logging.WARNING)
 logging.getLogger("aiohttp.server").setLevel(logging.WARNING)
 
+
 class ObjectSerializer(json.JSONEncoder):
     def default(self, obj):
         # First try to use __dict__ for custom objects
-        if hasattr(obj, '__dict__'):
+        if hasattr(obj, "__dict__"):
             return obj.__dict__
         # Convert iterables (generators, dict_items, etc.) to lists
         # Exclude strings and bytes which are also iterable
-        elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes)):
+        elif hasattr(obj, "__iter__") and not isinstance(obj, (str, bytes)):
             try:
                 return list(obj)
             except:
@@ -154,35 +177,75 @@ class ObjectSerializer(json.JSONEncoder):
         # Fall back to default behavior
         return json.JSONEncoder.default(self, obj)
 
+
 serializer = ObjectSerializer()
 app = web.Application()
-sio = socketio.AsyncServer(cors_allowed_origins='*')
-sio.attach(app, socketio_path=config.URL_PREFIX + 'socket.io')
+sio = socketio.AsyncServer(cors_allowed_origins="*")
+sio.attach(app, socketio_path=config.URL_PREFIX + "socket.io")
 routes = web.RouteTableDef()
+
 
 class Notifier(DownloadQueueNotifier):
     async def added(self, dl):
         log.info(f"Notifier: Download added - {dl.title}")
-        await sio.emit('added', serializer.encode(dl))
+        await sio.emit("added", serializer.encode(dl))
+        if telegram_bot is not None:
+            await telegram_bot.on_added(dl)
 
     async def updated(self, dl):
         log.debug(f"Notifier: Download updated - {dl.title}")
-        await sio.emit('updated', serializer.encode(dl))
+        await sio.emit("updated", serializer.encode(dl))
+        if telegram_bot is not None:
+            await telegram_bot.on_updated(dl)
 
     async def completed(self, dl):
         log.info(f"Notifier: Download completed - {dl.title}")
-        await sio.emit('completed', serializer.encode(dl))
+        await sio.emit("completed", serializer.encode(dl))
+        if telegram_bot is not None:
+            await telegram_bot.on_completed(dl)
 
     async def canceled(self, id):
         log.info(f"Notifier: Download canceled - {id}")
-        await sio.emit('canceled', serializer.encode(id))
+        await sio.emit("canceled", serializer.encode(id))
+        if telegram_bot is not None:
+            await telegram_bot.on_canceled(id)
 
     async def cleared(self, id):
         log.info(f"Notifier: Download cleared - {id}")
-        await sio.emit('cleared', serializer.encode(id))
+        await sio.emit("cleared", serializer.encode(id))
+
 
 dqueue = DownloadQueue(config, Notifier())
 app.on_startup.append(lambda app: dqueue.initialize())
+telegram_bot = None
+
+
+async def start_telegram_bot(app):
+    global telegram_bot
+    telegram_bot = TelegramBot(
+        dqueue=dqueue,
+        formats=get_available_formats(),
+        state_dir=config.STATE_DIR,
+        enabled=config.TELEGRAM_BOT_ENABLED,
+        default_playlist_item_limit=int(config.DEFAULT_OPTION_PLAYLIST_ITEM_LIMIT),
+        default_chapter_template=config.OUTPUT_TEMPLATE_CHAPTER,
+        stall_timeout_seconds=int(config.TELEGRAM_STALL_TIMEOUT_SECONDS),
+        hard_timeout_seconds=int(config.TELEGRAM_HARD_TIMEOUT_SECONDS),
+        max_urls_per_message=int(config.TELEGRAM_MAX_URLS_PER_MESSAGE),
+    )
+    await telegram_bot.start()
+
+
+async def stop_telegram_bot(app):
+    global telegram_bot
+    if telegram_bot is not None:
+        await telegram_bot.stop()
+        telegram_bot = None
+
+
+app.on_startup.append(start_telegram_bot)
+app.on_cleanup.append(stop_telegram_bot)
+
 
 class FileOpsFilter(DefaultFilter):
     def __call__(self, change_type: int, path: str) -> bool:
@@ -203,56 +266,60 @@ class FileOpsFilter(DefaultFilter):
         # Accept all change types for our file: modified, added, deleted
         return change_type in (Change.modified, Change.added, Change.deleted)
 
-def get_options_update_time(success=True, msg=''):
-    result = {
-        'success': success,
-        'msg': msg,
-        'update_time': None
-    }
+
+def get_options_update_time(success=True, msg=""):
+    result = {"success": success, "msg": msg, "update_time": None}
 
     # Only try to get file modification time if YTDL_OPTIONS_FILE is set and file exists
     if config.YTDL_OPTIONS_FILE and os.path.exists(config.YTDL_OPTIONS_FILE):
         try:
-            result['update_time'] = os.path.getmtime(config.YTDL_OPTIONS_FILE)
+            result["update_time"] = os.path.getmtime(config.YTDL_OPTIONS_FILE)
         except (OSError, IOError) as e:
-            log.warning(f"Could not get modification time for {config.YTDL_OPTIONS_FILE}: {e}")
-            result['update_time'] = None
+            log.warning(
+                f"Could not get modification time for {config.YTDL_OPTIONS_FILE}: {e}"
+            )
+            result["update_time"] = None
 
     return result
 
+
 async def watch_files():
     async def _watch_files():
-        async for changes in awatch(config.YTDL_OPTIONS_FILE, watch_filter=FileOpsFilter()):
+        async for changes in awatch(
+            config.YTDL_OPTIONS_FILE, watch_filter=FileOpsFilter()
+        ):
             success, msg = config.load_ytdl_options()
             result = get_options_update_time(success, msg)
-            await sio.emit('ytdl_options_changed', serializer.encode(result))
+            await sio.emit("ytdl_options_changed", serializer.encode(result))
 
-    log.info(f'Starting Watch File: {config.YTDL_OPTIONS_FILE}')
+    log.info(f"Starting Watch File: {config.YTDL_OPTIONS_FILE}")
     asyncio.create_task(_watch_files())
+
 
 if config.YTDL_OPTIONS_FILE:
     app.on_startup.append(lambda app: watch_files())
 
-@routes.post(config.URL_PREFIX + 'add')
+
+@routes.post(config.URL_PREFIX + "add")
 async def add(request):
     log.info("Received request to add download")
     post = await request.json()
     log.info(f"Request data: {post}")
-    url = post.get('url')
-    quality = post.get('quality')
+    url = post.get("url")
+    quality = post.get("quality")
     if not url or not quality:
         log.error("Bad request: missing 'url' or 'quality'")
         raise web.HTTPBadRequest()
-    format = post.get('format')
-    folder = post.get('folder')
-    custom_name_prefix = post.get('custom_name_prefix')
-    playlist_item_limit = post.get('playlist_item_limit')
-    auto_start = post.get('auto_start')
-    split_by_chapters = post.get('split_by_chapters')
-    chapter_template = post.get('chapter_template')
+    format = post.get("format")
+    folder = post.get("folder")
+    custom_name_prefix = post.get("custom_name_prefix")
+    playlist_item_limit = post.get("playlist_item_limit")
+    auto_start = post.get("auto_start")
+    split_by_chapters = post.get("split_by_chapters")
+    chapter_template = post.get("chapter_template")
 
     if custom_name_prefix is None:
-        custom_name_prefix = ''
+        custom_name_prefix = ""
     if auto_start is None:
         auto_start = True
     if playlist_item_limit is None:
@@ -264,69 +331,94 @@ async def add(request):
 
     playlist_item_limit = int(playlist_item_limit)
 
-    status = await dqueue.add(url, quality, format, folder, custom_name_prefix, playlist_item_limit, auto_start, split_by_chapters, chapter_template)
+    status = await dqueue.add(
+        url,
+        quality,
+        format,
+        folder,
+        custom_name_prefix,
+        playlist_item_limit,
+        auto_start,
+        split_by_chapters,
+        chapter_template,
+    )
     return web.Response(text=serializer.encode(status))
 
-@routes.post(config.URL_PREFIX + 'delete')
+
+@routes.post(config.URL_PREFIX + "delete")
 async def delete(request):
     post = await request.json()
-    ids = post.get('ids')
-    where = post.get('where')
-    if not ids or where not in ['queue', 'done']:
+    ids = post.get("ids")
+    where = post.get("where")
+    if not ids or where not in ["queue", "done"]:
         log.error("Bad request: missing 'ids' or incorrect 'where' value")
         raise web.HTTPBadRequest()
-    status = await (dqueue.cancel(ids) if where == 'queue' else dqueue.clear(ids))
+    status = await (dqueue.cancel(ids) if where == "queue" else dqueue.clear(ids))
     log.info(f"Download delete request processed for ids: {ids}, where: {where}")
     return web.Response(text=serializer.encode(status))
 
-@routes.post(config.URL_PREFIX + 'start')
+
+@routes.post(config.URL_PREFIX + "start")
 async def start(request):
     post = await request.json()
-    ids = post.get('ids')
+    ids = post.get("ids")
     log.info(f"Received request to start pending downloads for ids: {ids}")
     status = await dqueue.start_pending(ids)
     return web.Response(text=serializer.encode(status))
 
-@routes.get(config.URL_PREFIX + 'history')
+
+@routes.get(config.URL_PREFIX + "history")
 async def history(request):
-    history = { 'done': [], 'queue': [], 'pending': []}
+    history = {"done": [], "queue": [], "pending": []}
 
     for _, v in dqueue.queue.saved_items():
-        history['queue'].append(v)
+        history["queue"].append(v)
     for _, v in dqueue.done.saved_items():
-        history['done'].append(v)
+        history["done"].append(v)
     for _, v in dqueue.pending.saved_items():
-        history['pending'].append(v)
+        history["pending"].append(v)
 
     log.info("Sending download history")
     return web.Response(text=serializer.encode(history))
 
+
 _formats_json_candidates = [
-    os.path.join(os.path.dirname(__file__), 'formats.json'),             # Docker: copied alongside app/
-    os.path.join(os.path.dirname(__file__), '..', 'ui', 'src', 'formats.json'),  # Dev: repo layout
+    os.path.join(
+        os.path.dirname(__file__), "formats.json"
+    ),  # Docker: copied alongside app/
+    os.path.join(
+        os.path.dirname(__file__), "..", "ui", "src", "formats.json"
+    ),  # Dev: repo layout
 ]
-_formats_json_path = next((p for p in _formats_json_candidates if os.path.exists(p)), None)
+_formats_json_path = next(
+    (p for p in _formats_json_candidates if os.path.exists(p)), None
+)
 if _formats_json_path:
     with open(_formats_json_path) as _f:
         _available_formats = json.load(_f)
-    log.info(f'Loaded formats from {_formats_json_path}')
+    log.info(f"Loaded formats from {_formats_json_path}")
 else:
-    log.warning('formats.json not found, using empty format list')
+    log.warning("formats.json not found, using empty format list")
     _available_formats = []
+
 
 def get_available_formats():
     return _available_formats
 
+
 @sio.event
 async def connect(sid, environ):
     log.info(f"Client connected: {sid}")
-    await sio.emit('all', serializer.encode(dqueue.get()), to=sid)
-    await sio.emit('configuration', serializer.encode(config), to=sid)
-    await sio.emit('formats', serializer.encode(get_available_formats()), to=sid)
+    await sio.emit("all", serializer.encode(dqueue.get()), to=sid)
+    await sio.emit("configuration", serializer.encode(config), to=sid)
+    await sio.emit("formats", serializer.encode(get_available_formats()), to=sid)
     if config.CUSTOM_DIRS:
-        await sio.emit('custom_dirs', serializer.encode(get_custom_dirs()), to=sid)
+        await sio.emit("custom_dirs", serializer.encode(get_custom_dirs()), to=sid)
     if config.YTDL_OPTIONS_FILE:
-        await sio.emit('ytdl_options_changed', serializer.encode(get_options_update_time()), to=sid)
+        await sio.emit(
+            "ytdl_options_changed", serializer.encode(get_options_update_time()), to=sid
+        )
+
 
 def get_custom_dirs():
     def recursive_dirs(base):
@@ -336,9 +428,9 @@ def get_custom_dirs():
         def convert(p):
             s = str(p)
             if s.startswith(base):
-                s = s[len(base):]
+                s = s[len(base) :]
 
-            if s.startswith('/'):
+            if s.startswith("/"):
                 s = s[1:]
 
             return s
@@ -351,7 +443,7 @@ def get_custom_dirs():
                 return re.search(config.CUSTOM_DIRS_EXCLUDE_REGEX, d) is None
 
         # Recursively lists all subdirectories of DOWNLOAD_DIR
-        dirs = list(filter(include_dir, map(convert, path.glob('**/'))))
+        dirs = list(filter(include_dir, map(convert, path.glob("**/"))))
 
         return dirs
 
@@ -361,19 +453,20 @@ def get_custom_dirs():
     if config.DOWNLOAD_DIR != config.AUDIO_DOWNLOAD_DIR:
         audio_download_dir = recursive_dirs(config.AUDIO_DOWNLOAD_DIR)
 
-    return {
-        "download_dir": download_dir,
-        "audio_download_dir": audio_download_dir
-    }
+    return {"download_dir": download_dir, "audio_download_dir": audio_download_dir}
+
 
 @routes.get(config.URL_PREFIX)
 def index(request):
-    response = web.FileResponse(os.path.join(config.BASE_DIR, 'ui/dist/metube/browser/index.html'))
-    if 'metube_theme' not in request.cookies:
-        response.set_cookie('metube_theme', config.DEFAULT_THEME)
+    response = web.FileResponse(
+        os.path.join(config.BASE_DIR, "ui/dist/metube/browser/index.html")
+    )
+    if "metube_theme" not in request.cookies:
+        response.set_cookie("metube_theme", config.DEFAULT_THEME)
     return response
 
-@routes.get(config.URL_PREFIX + 'robots.txt')
+
+@routes.get(config.URL_PREFIX + "robots.txt")
 def robots(request):
     if config.ROBOTS_TXT:
         response = web.FileResponse(os.path.join(config.BASE_DIR, config.ROBOTS_TXT))
@@ -383,15 +476,17 @@ def robots(request):
         )
     return response
 
-@routes.get(config.URL_PREFIX + 'version')
-def version(request):
-    return web.json_response({
-        "yt-dlp": yt_dlp_version,
-        "version": os.getenv("METUBE_VERSION", "dev")
-    })
 
-if config.URL_PREFIX != '/':
-    @routes.get('/')
+@routes.get(config.URL_PREFIX + "version")
+def version(request):
+    return web.json_response(
+        {"yt-dlp": yt_dlp_version, "version": os.getenv("METUBE_VERSION", "dev")}
+    )
+
+
+if config.URL_PREFIX != "/":
+
+    @routes.get("/")
     def index_redirect_root(request):
         return web.HTTPFound(config.URL_PREFIX)
 
@@ -399,30 +494,48 @@ if config.URL_PREFIX != '/':
     def index_redirect_dir(request):
         return web.HTTPFound(config.URL_PREFIX)
 
-routes.static(config.URL_PREFIX + 'download/', config.DOWNLOAD_DIR, show_index=config.DOWNLOAD_DIRS_INDEXABLE)
-routes.static(config.URL_PREFIX + 'audio_download/', config.AUDIO_DOWNLOAD_DIR, show_index=config.DOWNLOAD_DIRS_INDEXABLE)
-routes.static(config.URL_PREFIX, os.path.join(config.BASE_DIR, 'ui/dist/metube/browser'))
+
+routes.static(
+    config.URL_PREFIX + "download/",
+    config.DOWNLOAD_DIR,
+    show_index=config.DOWNLOAD_DIRS_INDEXABLE,
+)
+routes.static(
+    config.URL_PREFIX + "audio_download/",
+    config.AUDIO_DOWNLOAD_DIR,
+    show_index=config.DOWNLOAD_DIRS_INDEXABLE,
+)
+routes.static(
+    config.URL_PREFIX, os.path.join(config.BASE_DIR, "ui/dist/metube/browser")
+)
 try:
     app.add_routes(routes)
 except ValueError as e:
-    if 'ui/dist/metube/browser' in str(e):
-        raise RuntimeError('Could not find the frontend UI static assets. Please run `node_modules/.bin/ng build` inside the ui folder') from e
+    if "ui/dist/metube/browser" in str(e):
+        raise RuntimeError(
+            "Could not find the frontend UI static assets. Please run `node_modules/.bin/ng build` inside the ui folder"
+        ) from e
     raise e
+
 
 # https://github.com/aio-libs/aiohttp/pull/4615 waiting for release
 # @routes.options(config.URL_PREFIX + 'add')
 async def add_cors(request):
     return web.Response(text=serializer.encode({"status": "ok"}))
 
-app.router.add_route('OPTIONS', config.URL_PREFIX + 'add', add_cors)
+
+app.router.add_route("OPTIONS", config.URL_PREFIX + "add", add_cors)
+
 
 async def on_prepare(request, response):
-    if 'Origin' in request.headers:
-        response.headers['Access-Control-Allow-Origin'] = request.headers['Origin']
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+    if "Origin" in request.headers:
+        response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+
 
 app.on_response_prepare.append(on_prepare)
- 
+
+
 def supports_reuse_port():
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -432,19 +545,34 @@ def supports_reuse_port():
     except (AttributeError, OSError):
         return False
 
+
 def isAccessLogEnabled():
     if config.ENABLE_ACCESSLOG:
         return access_logger
     else:
         return None
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logging.getLogger().setLevel(parseLogLevel(config.LOGLEVEL) or logging.INFO)
     log.info(f"Listening on {config.HOST}:{config.PORT}")
 
     if config.HTTPS:
         ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ssl_context.load_cert_chain(certfile=config.CERTFILE, keyfile=config.KEYFILE)
-        web.run_app(app, host=config.HOST, port=int(config.PORT), reuse_port=supports_reuse_port(), ssl_context=ssl_context, access_log=isAccessLogEnabled())
+        web.run_app(
+            app,
+            host=config.HOST,
+            port=int(config.PORT),
+            reuse_port=supports_reuse_port(),
+            ssl_context=ssl_context,
+            access_log=isAccessLogEnabled(),
+        )
     else:
-        web.run_app(app, host=config.HOST, port=int(config.PORT), reuse_port=supports_reuse_port(), access_log=isAccessLogEnabled())
+        web.run_app(
+            app,
+            host=config.HOST,
+            port=int(config.PORT),
+            reuse_port=supports_reuse_port(),
+            access_log=isAccessLogEnabled(),
+        )

--- a/app/telegram_bot.py
+++ b/app/telegram_bot.py
@@ -1,0 +1,572 @@
+import asyncio
+import contextvars
+import ipaddress
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.error import TelegramError
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from ytdl import DownloadQueue, DownloadInfo
+
+log = logging.getLogger("telegram_bot")
+
+
+URL_RE = re.compile(r"https?://[^\s<>()\[\]{}\"']+")
+TRAILING_PUNCTUATION = ".,;:!?)]}>'\""
+
+
+@dataclass
+class WatchedDownload:
+    chats: set[int] = field(default_factory=set)
+    started_at: float = field(default_factory=time.monotonic)
+    last_progress_at: float = field(default_factory=time.monotonic)
+    stall_notified: set[int] = field(default_factory=set)
+    timeout_notified: set[int] = field(default_factory=set)
+
+
+class TelegramBot:
+    def __init__(
+        self,
+        dqueue: DownloadQueue,
+        formats: list[dict[str, Any]],
+        state_dir: str,
+        enabled: bool,
+        default_playlist_item_limit: int,
+        default_chapter_template: str,
+        stall_timeout_seconds: int,
+        hard_timeout_seconds: int,
+        max_urls_per_message: int,
+    ):
+        self.dqueue = dqueue
+        self.formats = formats
+        self.state_dir = Path(state_dir)
+        self.enabled = enabled
+        self.default_playlist_item_limit = default_playlist_item_limit
+        self.default_chapter_template = default_chapter_template
+        self.stall_timeout_seconds = stall_timeout_seconds
+        self.hard_timeout_seconds = hard_timeout_seconds
+        self.max_urls_per_message = max_urls_per_message
+        self.bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+        self.allowed_chat_ids = self._parse_allowed_chat_ids(
+            os.environ.get("TELEGRAM_ALLOWED_CHAT_IDS", "")
+        )
+        self.config_path = self.state_dir / "telegram_bot_config.json"
+
+        self._app: Application | None = None
+        self._monitor_task: asyncio.Task | None = None
+        self._lock = asyncio.Lock()
+        self._chat_config: dict[str, dict[str, Any]] = {}
+        self._watched_downloads: dict[str, WatchedDownload] = {}
+        self._current_chat_id: contextvars.ContextVar[int | None] = (
+            contextvars.ContextVar("telegram_current_chat_id", default=None)
+        )
+
+    async def start(self):
+        if not self.enabled:
+            log.info("Telegram bot disabled")
+            return
+        if not self.bot_token:
+            log.error("Telegram bot enabled but TELEGRAM_BOT_TOKEN is missing")
+            return
+        if not self.allowed_chat_ids:
+            log.error("Telegram bot enabled but TELEGRAM_ALLOWED_CHAT_IDS is empty")
+            return
+
+        self._load_config()
+
+        self._app = Application.builder().token(self.bot_token).build()
+        self._app.add_handler(CommandHandler("start", self._start_command))
+        self._app.add_handler(CommandHandler("config", self._config_command))
+        self._app.add_handler(
+            CallbackQueryHandler(self._config_callback, pattern=r"^cfg:")
+        )
+        self._app.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self._text_message_handler)
+        )
+
+        await self._app.initialize()
+        await self._app.start()
+        if self._app.updater is None:
+            log.error("Telegram updater is unavailable")
+            return
+        await self._app.updater.start_polling(drop_pending_updates=True)
+        self._monitor_task = asyncio.create_task(self._monitor_downloads())
+        log.info("Telegram bot started")
+
+    async def stop(self):
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._monitor_task = None
+
+        if self._app is None:
+            return
+
+        if self._app.updater is not None:
+            await self._app.updater.stop()
+        await self._app.stop()
+        await self._app.shutdown()
+        self._app = None
+        log.info("Telegram bot stopped")
+
+    async def on_added(self, dl: DownloadInfo):
+        chat_id = self._current_chat_id.get()
+        if chat_id is None:
+            return
+        async with self._lock:
+            watched = self._watched_downloads.get(dl.url)
+            if watched is None:
+                watched = WatchedDownload()
+                self._watched_downloads[dl.url] = watched
+            watched.chats.add(chat_id)
+            watched.started_at = time.monotonic()
+            watched.last_progress_at = watched.started_at
+
+    async def on_updated(self, dl: DownloadInfo):
+        async with self._lock:
+            watched = self._watched_downloads.get(dl.url)
+            if watched is None:
+                return
+            if dl.status in ("downloading", "preparing"):
+                watched.last_progress_at = time.monotonic()
+
+    async def on_completed(self, dl: DownloadInfo):
+        async with self._lock:
+            watched = self._watched_downloads.pop(dl.url, None)
+
+        if watched is None:
+            return
+
+        if dl.status == "finished":
+            filename = getattr(dl, "filename", None)
+            suffix = f"\nFile: {filename}" if filename else ""
+            text = f"✅ Download complete: {dl.title}{suffix}"
+        else:
+            error_msg = dl.msg or dl.error or "Download failed"
+            text = f"❌ Download failed: {dl.title}\n{error_msg}"
+
+        for chat_id in watched.chats:
+            await self._send_message(chat_id, text)
+
+    async def on_canceled(self, url: str):
+        async with self._lock:
+            self._watched_downloads.pop(url, None)
+
+    def _parse_allowed_chat_ids(self, raw_ids: str) -> set[int]:
+        result = set()
+        for value in raw_ids.split(","):
+            value = value.strip()
+            if not value:
+                continue
+            try:
+                result.add(int(value))
+            except ValueError:
+                log.warning(
+                    f"Ignoring invalid TELEGRAM_ALLOWED_CHAT_IDS entry: {value}"
+                )
+        return result
+
+    def _get_chat_config(self, chat_id: int) -> dict[str, Any]:
+        key = str(chat_id)
+        config = self._chat_config.get(key)
+        if config is not None:
+            return config
+
+        defaults = {
+            "format": "mp4",
+            "quality": "best",
+            "folder": "",
+            "custom_name_prefix": "",
+            "playlist_item_limit": self.default_playlist_item_limit,
+            "auto_start": True,
+            "split_by_chapters": False,
+            "chapter_template": self.default_chapter_template,
+        }
+        self._chat_config[key] = defaults
+        self._save_config()
+        return defaults
+
+    def _load_config(self):
+        if not self.config_path.exists():
+            self._chat_config = {}
+            return
+        try:
+            self._chat_config = json.loads(self.config_path.read_text(encoding="utf-8"))
+            if not isinstance(self._chat_config, dict):
+                raise ValueError("Top-level config is not an object")
+        except Exception as exc:
+            log.error(f"Failed to read Telegram bot config: {exc}")
+            self._chat_config = {}
+
+    def _save_config(self):
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        temp_path = self.config_path.with_suffix(".tmp")
+        temp_path.write_text(
+            json.dumps(self._chat_config, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        temp_path.replace(self.config_path)
+
+    def _format_config_text(self, chat_id: int) -> str:
+        config = self._get_chat_config(chat_id)
+        return (
+            "Current download config:\n"
+            f"- Format: {config['format']}\n"
+            f"- Quality: {config['quality']}\n"
+            f"- Split by chapters: {'on' if config['split_by_chapters'] else 'off'}\n"
+            f"- Playlist item limit: {config['playlist_item_limit']}"
+        )
+
+    def _get_format_qualities(self, format_id: str) -> list[str]:
+        for item in self.formats:
+            if item.get("id") == format_id:
+                return [
+                    quality["id"]
+                    for quality in item.get("qualities", [])
+                    if "id" in quality
+                ]
+        return ["best"]
+
+    def _build_main_config_keyboard(self, chat_id: int) -> InlineKeyboardMarkup:
+        config = self._get_chat_config(chat_id)
+        return InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        f"Format: {config['format']}", callback_data="cfg:menu:format"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"Quality: {config['quality']}",
+                        callback_data="cfg:menu:quality",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"Split Chapters: {'on' if config['split_by_chapters'] else 'off'}",
+                        callback_data="cfg:toggle:split",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        f"Playlist Limit: {config['playlist_item_limit']}",
+                        callback_data="cfg:menu:limit",
+                    )
+                ],
+            ]
+        )
+
+    def _build_format_keyboard(self) -> InlineKeyboardMarkup:
+        rows = []
+        for item in self.formats:
+            fmt = item.get("id")
+            if not fmt:
+                continue
+            rows.append(
+                [InlineKeyboardButton(fmt, callback_data=f"cfg:set:format:{fmt}")]
+            )
+        rows.append([InlineKeyboardButton("Back", callback_data="cfg:menu:main")])
+        return InlineKeyboardMarkup(rows)
+
+    def _build_quality_keyboard(self, format_id: str) -> InlineKeyboardMarkup:
+        rows = [
+            [InlineKeyboardButton(quality, callback_data=f"cfg:set:quality:{quality}")]
+            for quality in self._get_format_qualities(format_id)
+        ]
+        rows.append([InlineKeyboardButton("Back", callback_data="cfg:menu:main")])
+        return InlineKeyboardMarkup(rows)
+
+    def _build_playlist_limit_keyboard(self) -> InlineKeyboardMarkup:
+        values = [0, 1, 5, 10, 20]
+        rows = [
+            [InlineKeyboardButton(str(value), callback_data=f"cfg:set:limit:{value}")]
+            for value in values
+        ]
+        rows.append([InlineKeyboardButton("Back", callback_data="cfg:menu:main")])
+        return InlineKeyboardMarkup(rows)
+
+    def _extract_urls(self, text: str) -> list[str]:
+        urls = []
+        seen = set()
+        for match in URL_RE.findall(text):
+            normalized = match.rstrip(TRAILING_PUNCTUATION)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            urls.append(normalized)
+        return urls
+
+    def _validate_url(self, raw_url: str) -> tuple[bool, str]:
+        try:
+            parsed = urlsplit(raw_url)
+        except Exception:
+            return False, "invalid URL format"
+
+        if parsed.scheme not in ("http", "https"):
+            return False, "only http/https URLs are allowed"
+        if not parsed.netloc:
+            return False, "URL host is missing"
+
+        host = (parsed.hostname or "").strip().lower()
+        if not host:
+            return False, "URL host is empty"
+        if host in {"localhost"} or host.endswith(".local"):
+            return False, "local network hosts are not allowed"
+
+        try:
+            ip = ipaddress.ip_address(host)
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+                or ip.is_unspecified
+            ):
+                return False, "private/local IP targets are not allowed"
+        except ValueError:
+            pass
+
+        return True, ""
+
+    async def _start_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        chat_id = self._get_authorized_chat_id(update)
+        if chat_id is None:
+            return
+        text = (
+            "Hi! Send one or more links and I will queue them for download.\n"
+            "Use /config to set default format/quality for this chat."
+        )
+        await self._send_message(chat_id, text)
+
+    async def _config_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        chat_id = self._get_authorized_chat_id(update)
+        if chat_id is None:
+            return
+        text = self._format_config_text(chat_id)
+        await self._send_message(
+            chat_id,
+            text,
+            reply_markup=self._build_main_config_keyboard(chat_id),
+        )
+
+    async def _config_callback(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        query = update.callback_query
+        if query is None or query.data is None or query.message is None:
+            return
+        chat_id = self._get_authorized_chat_id(update)
+        if chat_id is None:
+            return
+
+        parts = query.data.split(":")
+        await query.answer()
+        if len(parts) < 3:
+            return
+
+        action = parts[1]
+        target = parts[2]
+        config = self._get_chat_config(chat_id)
+
+        if action == "menu":
+            if target == "main":
+                await query.edit_message_text(
+                    self._format_config_text(chat_id),
+                    reply_markup=self._build_main_config_keyboard(chat_id),
+                )
+                return
+            if target == "format":
+                await query.edit_message_text(
+                    "Select format", reply_markup=self._build_format_keyboard()
+                )
+                return
+            if target == "quality":
+                await query.edit_message_text(
+                    "Select quality",
+                    reply_markup=self._build_quality_keyboard(config["format"]),
+                )
+                return
+            if target == "limit":
+                await query.edit_message_text(
+                    "Select playlist limit",
+                    reply_markup=self._build_playlist_limit_keyboard(),
+                )
+                return
+
+        if action == "toggle" and target == "split":
+            config["split_by_chapters"] = not bool(config.get("split_by_chapters"))
+            self._save_config()
+            await query.edit_message_text(
+                self._format_config_text(chat_id),
+                reply_markup=self._build_main_config_keyboard(chat_id),
+            )
+            return
+
+        if action == "set" and len(parts) >= 4:
+            value = parts[3]
+            if target == "format":
+                config["format"] = value
+                available = self._get_format_qualities(value)
+                if config["quality"] not in available:
+                    config["quality"] = available[0]
+            elif target == "quality":
+                if value in self._get_format_qualities(config["format"]):
+                    config["quality"] = value
+            elif target == "limit":
+                try:
+                    config["playlist_item_limit"] = int(value)
+                except ValueError:
+                    pass
+            self._save_config()
+            await query.edit_message_text(
+                self._format_config_text(chat_id),
+                reply_markup=self._build_main_config_keyboard(chat_id),
+            )
+
+    async def _text_message_handler(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        chat_id = self._get_authorized_chat_id(update)
+        if chat_id is None:
+            return
+
+        text = update.effective_message.text if update.effective_message else ""
+        urls = self._extract_urls(text or "")
+        if not urls:
+            return
+
+        if len(urls) > self.max_urls_per_message:
+            await self._send_message(
+                chat_id,
+                f"Too many links in one message ({len(urls)}). Maximum allowed: {self.max_urls_per_message}.",
+            )
+            urls = urls[: self.max_urls_per_message]
+
+        valid_urls = []
+        rejected = []
+        for url in urls:
+            is_valid, reason = self._validate_url(url)
+            if is_valid:
+                valid_urls.append(url)
+            else:
+                rejected.append((url, reason))
+
+        if rejected:
+            rejected_text = "\n".join(f"- {url} ({reason})" for url, reason in rejected)
+            await self._send_message(
+                chat_id, f"Ignored invalid links:\n{rejected_text}"
+            )
+
+        if not valid_urls:
+            return
+
+        config = self._get_chat_config(chat_id)
+        queued_count = 0
+        errors = []
+        for url in valid_urls:
+            token = self._current_chat_id.set(chat_id)
+            try:
+                status = await self.dqueue.add(
+                    url,
+                    config["quality"],
+                    config["format"],
+                    config["folder"],
+                    config["custom_name_prefix"],
+                    config["playlist_item_limit"],
+                    config["auto_start"],
+                    config["split_by_chapters"],
+                    config["chapter_template"],
+                )
+            finally:
+                self._current_chat_id.reset(token)
+
+            if status.get("status") == "error":
+                errors.append(f"- {url}: {status.get('msg', 'unknown error')}")
+            else:
+                queued_count += 1
+
+        if queued_count > 0:
+            await self._send_message(
+                chat_id, f"Queued {queued_count} link(s) with current chat config."
+            )
+        if errors:
+            error_text = "\n".join(errors)
+            await self._send_message(chat_id, f"Some links failed:\n{error_text}")
+
+    def _get_authorized_chat_id(self, update: Update) -> int | None:
+        chat = update.effective_chat
+        if chat is None:
+            return None
+        if chat.id not in self.allowed_chat_ids:
+            log.warning(f"Rejected Telegram update from unauthorized chat {chat.id}")
+            return None
+        return chat.id
+
+    async def _monitor_downloads(self):
+        while True:
+            await asyncio.sleep(15)
+            now = time.monotonic()
+            messages: list[tuple[int, str]] = []
+            async with self._lock:
+                for url, watched in self._watched_downloads.items():
+                    since_progress = now - watched.last_progress_at
+                    elapsed = now - watched.started_at
+                    for chat_id in watched.chats:
+                        if (
+                            since_progress > self.stall_timeout_seconds
+                            and chat_id not in watched.stall_notified
+                        ):
+                            watched.stall_notified.add(chat_id)
+                            messages.append(
+                                (
+                                    chat_id,
+                                    f"⚠️ Download seems stalled for {int(since_progress)}s:\n{url}",
+                                )
+                            )
+
+                        if (
+                            elapsed > self.hard_timeout_seconds
+                            and chat_id not in watched.timeout_notified
+                        ):
+                            watched.timeout_notified.add(chat_id)
+                            messages.append(
+                                (
+                                    chat_id,
+                                    f"⏱️ Download is taking longer than expected ({int(elapsed)}s):\n{url}",
+                                )
+                            )
+
+            for chat_id, text in messages:
+                await self._send_message(chat_id, text)
+
+    async def _send_message(
+        self, chat_id: int, text: str, reply_markup: InlineKeyboardMarkup | None = None
+    ):
+        if self._app is None:
+            return
+        try:
+            await self._app.bot.send_message(
+                chat_id=chat_id, text=text, reply_markup=reply_markup
+            )
+        except TelegramError as exc:
+            log.error(f"Failed to send Telegram message to {chat_id}: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "bgutil-ytdlp-pot-provider==1.2.2",
     "beautifulsoup4==4.14.3",
     "requests==2.32.5",
+    "python-telegram-bot==21.11.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -180,6 +180,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },
@@ -386,6 +391,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -405,6 +438,7 @@ dependencies = [
     { name = "curl-cffi" },
     { name = "mutagen" },
     { name = "python-socketio" },
+    { name = "python-telegram-bot" },
     { name = "requests" },
     { name = "watchfiles" },
     { name = "yt-dlp", extra = ["curl-cffi", "default"] },
@@ -424,6 +458,7 @@ requires-dist = [
     { name = "curl-cffi", specifier = ">=0.5.10,<0.14" },
     { name = "mutagen", specifier = "==1.47.0" },
     { name = "python-socketio", specifier = "==5.16.0" },
+    { name = "python-telegram-bot", specifier = "==21.11.1" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "watchfiles", specifier = "==1.1.1" },
     { name = "yt-dlp", extras = ["default", "curl-cffi"] },
@@ -656,6 +691,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b8/55/5d8af5884283b58e4405580bcd84af1d898c457173c708736e065f10ca4a/python_socketio-5.16.0.tar.gz", hash = "sha256:f79403c7f1ba8b84460aa8fe4c671414c8145b21a501b46b676f3740286356fd", size = 127120, upload-time = "2025-12-24T23:51:48.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d2/2ccc2b69a187b80fda3152745670cfba936704f296a9fa54c6c8ac694d12/python_socketio-5.16.0-py3-none-any.whl", hash = "sha256:d95802961e15c7bd54ecf884c6e7644f81be8460f0a02ee66b473df58088ee8a", size = 79607, upload-time = "2025-12-24T23:51:47.2Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "21.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/74/3ebdc3ee2c323b4577fcc57542f71aa064ac9dac154af0c2f5805e1b9fbd/python_telegram_bot-21.11.1.tar.gz", hash = "sha256:2abda5202f27a838f35e8140e5292af0f4f8fad6c2e5123b2defadd5f4e8ca02", size = 442624, upload-time = "2025-03-01T11:46:54.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/3b/8f6372e580ba4514335873f64924eb80b80c3d3f8359c2bb2e07bb6d01b9/python_telegram_bot-21.11.1-py3-none-any.whl", hash = "sha256:17f933a7a0569f519d9b672e06d71c29ab3688f1ec575ba59a3ca37922481113", size = 676058, upload-time = "2025-03-01T11:46:52.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add an optional Telegram bot service that accepts one or more links, validates/sanitizes URLs, and queues downloads in MeTube
- add per-chat `/config` settings (format, quality, chapter split toggle, playlist limit) persisted under `STATE_DIR`
- send Telegram notifications for completion/failures plus stall/long-running warnings
- wire bot lifecycle into app startup/cleanup and update docs/dependencies

## Validation
- `python3 -m compileall app`